### PR TITLE
nota: comando en windows cat->type

### DIFF
--- a/Notebooks/Clase1a_Intro-Python-IPython.ipynb
+++ b/Notebooks/Clase1a_Intro-Python-IPython.ipynb
@@ -147,7 +147,20 @@
      "metadata": {},
      "source": [
       "<div class=\"alert alert-info\"><strong>Tip de IPython</strong>:\n",
-      "`cat` es un comando de la l\u00ednea de comandos, no propio de Python. Anteponiendo `!` a comandos de la terminal como `cd, ls, cat ...` se pueden ejecutar desde aqu\u00ed.\n",
+      "`cat` es un comando de la l\u00ednea de comandos, no propio de Python. Anteponiendo `!` a comandos de la terminal como `cd`, `ls`, `cat`... se pueden ejecutar desde aqu\u00ed.\n",
+      "</div>"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "<div class=\"alert\"><strong>Si est\u00e1s usando Windows</strong> y acabas de obtener un error, susituye la l\u00ednea anterior por:<br>\n",
+      "    `!type ..\\static\\mi_primer_script.py`\n",
+      "\n",
+      "<br><br>\n",
+      "`type` es un comando similar en Windows a `cat`. De nuevo, podemos ejecutar comandos como `cd`, `dir`, `type`, `find`...  desde aqu\u00ed anteponiendo `!` y utilizando `\\` en lugar de `/` para la ruta donde se encuentra el archivo.\n",
+      "    \n",
       "</div>"
      ]
     },


### PR DESCRIPTION
Este notebook empieza con una llamada a la línea de comandos desde una
celda. No obstante, el comando `cat` sólo funciona en Linux y Mac por lo
que se ha añadido una nota para que usuarios de Windows puedan
reproducir este comando sin problemas :wink:  